### PR TITLE
HNY wallet balance: Perform contract polling

### DIFF
--- a/src/components/Dashboard/BalanceModule.js
+++ b/src/components/Dashboard/BalanceModule.js
@@ -1,19 +1,18 @@
 import React from 'react'
 import { Box, GU, Split, useLayout, useTheme } from '@1hive/1hive-ui'
-import Profile from './Profile'
-import Balance from './Balance'
 import AccountBanner from './AccountBanner'
-import { useCourtConfig } from '../../providers/CourtConfig'
+import Balance from './Balance'
+import Profile from './Profile'
 
-import { getAccountStatus } from '../../utils/account-utils'
+import { useCourtConfig } from '../../providers/CourtConfig'
 import { useWallet } from '../../providers/Wallet'
 import {
   getTotalUnlockedActiveBalance,
   getTotalLockedANJDistribution,
   getTotalEffectiveInactiveBalance,
 } from '../../utils/balance-utils'
+import { getAccountStatus } from '../../utils/account-utils'
 
-// TODO: import icons from aragon-ui when available
 import walletIcon from '../../assets/IconWallet.svg'
 import inactiveANJIcon from '../../assets/IconANJInactive.svg'
 import activeANJIcon from '../../assets/IconANJActive.svg'

--- a/src/hooks/subscription-hooks.js
+++ b/src/hooks/subscription-hooks.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useQuery } from 'urql'
-import { useANJBalanceOf } from './useCourtContracts'
+import { useANJBalanceOfPolling } from './useCourtContracts'
 import { useCourtConfig } from '../providers/CourtConfig'
 
 // queries
@@ -78,7 +78,7 @@ function useJurorTreasuryBalances(jurorId) {
  * latest 24h movements and all subscription fees claimed by the juror
  */
 export function useJurorBalancesSubscription(jurorId) {
-  const walletBalance = useANJBalanceOf(jurorId)
+  const walletBalance = useANJBalanceOfPolling(jurorId)
   // Juror ANJ balances, 24h movements and subscritpion claimed fees
   const { data: jurorData, error: jurorError } = useJuror(jurorId)
   const {

--- a/src/hooks/useCourtContracts.js
+++ b/src/hooks/useCourtContracts.js
@@ -849,3 +849,34 @@ export function useTotalANTStakedPolling(timeout = 1000) {
 
   return [totalANTStaked, error]
 }
+
+export function useANJBalanceOf(juror) {
+  const anjTokenContract = useANJTokenContract()
+  const [balance, setBalance] = useState(bigNum(-1))
+
+  useEffect(() => {
+    let cancelled = false
+
+    const getActiveBalanceOf = async () => {
+      if (!anjTokenContract) return
+
+      retryMax(() => anjTokenContract.balanceOf(juror))
+        .then(balance => {
+          if (!cancelled) {
+            setBalance(balance)
+          }
+        })
+        .catch(err => {
+          captureException(err)
+        })
+    }
+
+    getActiveBalanceOf()
+
+    return () => {
+      cancelled = true
+    }
+  }, [anjTokenContract, juror])
+
+  return balance
+}

--- a/src/queries/balances.js
+++ b/src/queries/balances.js
@@ -1,13 +1,5 @@
 import gql from 'graphql-tag'
 
-export const JurorANJWalletBalance = gql`
-  query JurorANJWalletBalance($id: ID!) {
-    anjbalance(id: $id) {
-      amount
-    }
-  }
-`
-
 export const JurorANJBalances = gql`
   query JurorANJBalances($id: ID!, $from: BigInt!) {
     juror(id: $id) {


### PR DESCRIPTION
closes #15 

Instead of relying on the subgraph for the HNY balance, we are performing a contract call polling. 
The reason for this is that the HNY token is deployed way before the court deployment will be, it will be difficult to make the subgraph track all keepers HNY balances, as the HNY template would be cerated at the block at which the court is created, meaning that it will only process transfer events from that block.

Note that we are still naming everything as ANJ, once we decide to update it to `HNY` will do so in a full PR.