### PR TITLE
Fix the celeste server url

### DIFF
--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -29,9 +29,9 @@ export function courtServerEndpoint() {
   }
 
   const networkType = getNetworkType(CHAIN_ID)
-  return `https://celeste${
+  return `https://celeste-server${
     networkType === 'main' ? '' : `-${COURT_SERVER_NAME || networkType}`
-  }.backend.1hive.org`
+  }.1hive.org`
 }
 
 export function graphEndpoint() {


### PR DESCRIPTION
The dashboard is trying to fetch from the wrong URL, this PR fixes it.

![image](https://user-images.githubusercontent.com/40803711/109925673-68335580-7c98-11eb-9db3-8bb4c1bfedda.png)

The correct address should be: `celeste-server-rinkeby.1hive.org`