### PR TITLE
Total fees: Avoid zero division 

### DIFF
--- a/src/utils/dispute-utils.js
+++ b/src/utils/dispute-utils.js
@@ -589,7 +589,8 @@ export function getRoundFees(round, courtConfig) {
   if (round.number === maxRegularAppealRounds) {
     return jurorFee
       .mul(round.jurorsNumber)
-      .div(FINAL_ROUND_WEIGHT_PRECISION.mul(finalRoundReduction).div(PCT_BASE))
+      .div(FINAL_ROUND_WEIGHT_PRECISION.mul(finalRoundReduction))
+      .div(PCT_BASE)
   }
 
   // Regular round


### PR DESCRIPTION
If the finalRoundReduction is pretty insignificant, it causes  a divide by zero when calculating totalFees.