### PR TITLE
Disputables: Update subgraph mapping

### DIFF
--- a/src/disputables/index.js
+++ b/src/disputables/index.js
@@ -46,12 +46,12 @@ export async function describeDisputedAction(
     if (DISPUTABLE_ACTIONS.has(appId)) {
       const { entityPath, scriptExtractor } = DISPUTABLE_ACTIONS.get(appId)
 
-      const evmScript = await scriptExtractor(
+      const evmScript = await scriptExtractor({
         disputableAddress,
         disputableActionId,
-        appId,
-        disputeId
-      )
+        disputableAppId: appId,
+        disputeId,
+      })
 
       const disputedActionURL = buildDisputedActionUrl(
         organization,

--- a/src/disputables/mappings.js
+++ b/src/disputables/mappings.js
@@ -48,19 +48,19 @@ export const DISPUTABLE_SUBGRAPH_URLS = new Map([
   ...VOTING_APP_IDS.map(appId => [
     appId,
     {
-      main:
-        'https://graph.backend.aragon.org/subgraphs/name/aragon/aragon-dvoting-mainnet-staging', // TODO: - Update to main subgraph when available, - Add xdai
+      xdai:
+        'https://api.thegraph.com/subgraphs/name/1hive/disputable-honey-pot',
       rinkeby:
-        'https://api.thegraph.com/subgraphs/name/aragon/aragon-dvoting-rinkeby',
-      ropsten:
-        'https://api.thegraph.com/subgraphs/name/aragon/aragon-dvoting-ropsten',
+        'https://api.thegraph.com/subgraphs/name/1hive/disputable-honey-pot-rinkeby',
     },
   ]),
   ...CONVICTION_VOTING_APP_IDS.map(appId => [
     appId,
     {
+      xdai:
+        'https://api.thegraph.com/subgraphs/name/1hive/disputable-honey-pot',
       rinkeby:
-        'https://api.thegraph.com/subgraphs/name/1hive/disputable-honey-pot-rinkeby', // TODO:  - Update to general subgraph, - Add xdai
+        'https://api.thegraph.com/subgraphs/name/1hive/disputable-honey-pot-rinkeby', // TODO:  - Update to general subgraph
     },
   ]),
 ])

--- a/src/disputables/queries.js
+++ b/src/disputables/queries.js
@@ -3,7 +3,6 @@ import { Client } from 'urql'
 import { getSubgraphByAppId } from './connect-endpoints'
 
 export function performDisputableProposalQuery(
-  disputableAddress,
   disputableActionId,
   disputableAppId,
   disputeId
@@ -18,7 +17,6 @@ export function performDisputableProposalQuery(
 }
 
 export function performDisputableVotingQuery(
-  disputableAddress,
   disputableActionId,
   disputableAppId,
   disputeId
@@ -26,9 +24,9 @@ export function performDisputableVotingQuery(
   // Disputable voting now saves the hash of the evmScript so we need to get it from the subgraph.
   const subgraphUrl = getSubgraphByAppId(disputableAppId)
 
-  return performQuery(subgraphUrl, disputableVotingQuery, {
-    id: disputableAddress,
-    voteId: disputableActionId,
+  return performQuery(subgraphUrl, disputableProposalQuery, {
+    proposalId: disputableActionId,
+    disputeId,
   })
 }
 
@@ -45,16 +43,7 @@ const disputableProposalQuery = gql`
       requestedAmount
       metadata
       stable
-    }
-  }
-`
-
-const disputableVotingQuery = gql`
-  query DisputableVoting($id: ID!, $voteId: BigInt!) {
-    disputableVoting(id: $id) {
-      votes(where: { voteId: $voteId }) {
-        script
-      }
+      script
     }
   }
 `

--- a/src/disputables/scriptExtractors.js
+++ b/src/disputables/scriptExtractors.js
@@ -11,18 +11,17 @@ import tokenAbi from '../abi/ERC20.json'
 import { bigNum, formatTokenAmount } from '../lib/math-utils'
 
 // TODO: Make a general propsoal extractor, ideally by arbitrable
-export async function convictionVotingExtractor(
+export async function convictionVotingExtractor({
   disputableAddress,
   disputableActionId,
   disputableAppId,
-  disputeId
-) {
+  disputeId,
+}) {
   const disputableConvictionVotingContract = getContract(
     disputableAddress,
     disputableConvictionVotingAbi
   )
   const { data } = await performDisputableProposalQuery(
-    disputableAddress,
     disputableActionId,
     disputableAppId,
     disputeId
@@ -59,7 +58,10 @@ export async function convictionVotingExtractor(
   }
 }
 
-export async function delayExtractor(disputableAddress, disputableActionId) {
+export async function delayExtractor({
+  disputableAddress,
+  disputableActionId,
+}) {
   return {
     script: await extractFromContract(
       disputableDelayAbi,
@@ -71,10 +73,10 @@ export async function delayExtractor(disputableAddress, disputableActionId) {
   }
 }
 
-export async function dandelionVotingExtractor(
+export async function dandelionVotingExtractor({
   disputableAddress,
-  disputableActionId
-) {
+  disputableActionId,
+}) {
   return {
     script: await extractFromContract(
       disputableDandelionVotingAbi,
@@ -86,22 +88,22 @@ export async function dandelionVotingExtractor(
   }
 }
 
-export async function votingExtractor(
-  disputableAddress,
+export async function votingExtractor({
   disputableActionId,
-  disputableAppId
-) {
+  disputableAppId,
+  disputeId,
+}) {
   const { data } = await performDisputableVotingQuery(
-    disputableAddress,
     disputableActionId,
-    disputableAppId
+    disputableAppId,
+    disputeId
   )
 
-  if (!data?.disputableVoting?.votes?.length) {
+  if (!data?.proposals?.length) {
     throw new Error('Failed to fetch evmScript from subgraph')
   }
 
-  return { script: data.disputableVoting.votes[0].script }
+  return { script: data.proposals[0].script }
 }
 
 async function extractFromContract(


### PR DESCRIPTION
Uses disputable honey-pot subgraph for fetching disputable voting scripts and conviction voting proposal metadata

In the future we may need to have a general purpose subgraph when more DAOS start integrating Celeste