### PR TITLE
fix `your` typo in content.js

### DIFF
--- a/src/components/Onboarding/content.js
+++ b/src/components/Onboarding/content.js
@@ -180,7 +180,7 @@ highlights.rinkeby = [
       small: null,
       large: (
         <span>
-          View all live disputes or only ones your adjudicating. From here you
+          View all live disputes or only ones you are adjudicating. From here you
           can explore the details, comments, and timeline for any dispute.
         </span>
       ),
@@ -360,7 +360,7 @@ highlights.xdai = [
       small: null,
       large: (
         <span>
-          View all live disputes or only ones your adjudicating. From here you
+          View all live disputes or only ones you are adjudicating. From here you
           can explore the details, comments, and timeline for any dispute.
         </span>
       ),


### PR DESCRIPTION
This PR fixes a small typo in the onboarding content about "Dispute list"

![Image with 'your' typo](https://media.discordapp.net/attachments/762765002963681280/863478848679444520/Screen_Shot_2021-07-10_at_10.52.48.png?width=415&height=586)

link to feedback report: https://discord.com/channels/698287700834517064/762765002963681280/863477242930921482

:)

paired with @blazingthirdeye and @boring877