### PR TITLE
Handle challenger

### DIFF
--- a/src/hooks/useDisputes.js
+++ b/src/hooks/useDisputes.js
@@ -190,7 +190,11 @@ async function processDisputableData(dispute) {
  * @returns {Object | null} Dispute processed data.
  */
 async function processRawDisputeData(dispute) {
-  const { description: disputeDescription, metadataUri } = dispute
+  const {
+    description: disputeDescription,
+    metadataUri,
+    plaintiff: _plaintiff,
+  } = dispute
   let data
 
   if (metadataUri) {
@@ -223,7 +227,7 @@ async function processRawDisputeData(dispute) {
         disputedActionText = '',
         disputedActionURL = '',
         organization = '',
-        plaintiff = '',
+        plaintiff = _plaintiff ?? '',
       } = data
 
       return {


### PR DESCRIPTION
I recently tweaked the GovernQueue contract used in Quests to include the challenger in the payload in order for celeste to know who actually raised a dispute (the quest claim challenger). This is a backward-compatible update to display it in the celeste view instead of the GovernQueue address as the challenger. 