### PR TITLE
Trim slash of gateway if already end with it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: Cache yarn modules
-        uses: actions/cache@v2
-        with:
-          path: "**/node_modules"
-          key: yarn-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         run: yarn install
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           path: "**/node_modules"
           key: yarn-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install
       - name: Lint
         run: yarn lint
       - name: Build Celeste Dashboard

--- a/src/hooks/useDisputes.js
+++ b/src/hooks/useDisputes.js
@@ -211,12 +211,13 @@ async function processRawDisputeData(dispute) {
       // Note that in this case, we expect the agreement's location to be relative to the
       // metadata URI. For example, if the metadataUri is `<cid>/metadata.json`, the agreement's
       // location would be `<cid>/<agreement>`
+      let ipfsEndpoint = defaultIpfsEndpoint()
+      if (ipfsEndpoint.endsWith('/')) {
+        ipfsEndpoint = ipfsEndpoint.slice(0, -1)
+      }
       const agreementUrl =
         ipfsPath && agreementText
-          ? resolvePathname(
-              agreementText,
-              `${defaultIpfsEndpoint()}/${ipfsPath}`
-            )
+          ? resolvePathname(agreementText, `${ipfsEndpoint}/${ipfsPath}`)
           : ''
 
       const {

--- a/src/lib/ipfs-utils.js
+++ b/src/lib/ipfs-utils.js
@@ -7,7 +7,11 @@ const TEST_IPFS_REGEX = /(Qm[a-zA-Z0-9]{44})/
 const REQUEST_TIMEOUT = 60000
 
 export const ipfsGet = async cid => {
-  const endpoint = `${getIpfsGateway()}/${cid}`
+  let ipfsGateway = getIpfsGateway()
+  if (ipfsGateway.endsWith('/')) {
+    ipfsGateway = ipfsGateway.slice(0, -1)
+  }
+  const endpoint = `${ipfsGateway}/${cid}`
   try {
     const result = await fetch(endpoint, { timeout: REQUEST_TIMEOUT })
     const data = await result.text()


### PR DESCRIPTION
## Problem
Cant fetch ipfs because the link of ipfs is double slashed: 
![image](https://github.com/1Hive/celeste-dashboard/assets/13890618/4db94085-bc95-4eb8-8080-a8ffcb87cdd1)


## Fix
Check if gateway ends with /, and remove it if its the case 